### PR TITLE
Updating accessibility attribute to progressbar

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -334,7 +334,7 @@ const controls = {
                     min: 0,
                     max: 100,
                     value: 0,
-                    role: 'presentation',
+                    role: 'progressbar',
                     'aria-hidden': true,
                 },
                 attributes,


### PR DESCRIPTION
aXe complains this is a non-compatible attribute to be set as `role="presentation"`

### Link to related issue (if applicable)

### Summary of proposed changes

### Checklist
- [x] Use `develop` as the base branch
- [ ] Exclude the gulp build (`/dist` changes) from the PR
- [ ] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
